### PR TITLE
Fix custom tags scripts

### DIFF
--- a/lib/configure/configure.js
+++ b/lib/configure/configure.js
@@ -1,6 +1,7 @@
 var checkDependencies = require("./check-dependencies");
 var installPackages = require("./install-packages");
 var addPackageConfiguration = require("./add-package-configuration");
+var fsx = require("../fs_extras");
 var _ = require("lodash");
 var path = require("path");
 
@@ -57,8 +58,14 @@ var makeBitDocs = function(siteConfig){
 				siteConfig.generators.push(generator);
 			},
 			tags: function(siteConfig, tags){
-		        siteConfig.tags = _.assign(siteConfig.tags || {}, tags);
-		    }
+				var tagFn;
+				if(typeof siteConfig.tags === "string") {
+					tagFn = require(fsx.smartJoin(siteConfig.cwd, siteConfig.tags));
+					tags = tagFn(tags);
+					siteConfig.tags = null;
+				}
+				siteConfig.tags = _.assign(siteConfig.tags || {}, tags);
+			}
 		},
 		register: function(name){
 			if(this.handlers[name]) {


### PR DESCRIPTION
`siteConfig.md` states:

> [tags] A path to a module that determines which tags will be used to process the site. The module must export a function that takes the default [documentjs.tags] object and returns the tags that will be used.

This doesn't happen. Currently the "tags" option in the site config is interpreted as an object and `assign()`ed into the tag definitions.  This patch restores a `require()` to the tags module when processing options.
