### PR TITLE
improvement: log source file path for unable warning

### DIFF
--- a/lib/process/add_doc_object_to_doc_map.js
+++ b/lib/process/add_doc_object_to_doc_map.js
@@ -21,7 +21,7 @@ module.exports = function(docObject, docMap, filename){
 			_.get(docObject,"src.path", filename);
 		}
 	} else if(!_.isEmpty( _.omit(docObject,['body','description']) )  && docObject.type !== "hide"){
-		console.log("WARNING: Unable to document ",JSON.stringify(docObject).substr(0,50));
+		console.log("WARNING: Unable to document ",JSON.stringify(docObject.src.path));
 	}
 };
 


### PR DESCRIPTION
Is there any instance when the json docObject won't have a path to print?

EDIT:

Looks like it can also contain `line` and `codeLine`:

```
WARNING: Unable to document  {"src":{"line":124,"codeLine":124,"path":"node_mod
```