### PR TITLE
Add cache busting flag

### DIFF
--- a/bin/bit-docs
+++ b/bin/bit-docs
@@ -14,8 +14,12 @@ var argv = yargs
 	.string("_")
 
 	.alias("f","forceBuild")
-	.describe("f","Force rebuilding the templates, js, and css.")
+	.describe("f","Force redownloading of plugins and rebuilding the templates, js, and css.")
 	.boolean("f")
+
+	.alias("c","cacheBust")
+	.describe("c","Bust cached templates, js, and css.")
+	.boolean("c")
 
 	.alias("d","debug")
 	.describe("d","Turn on debugging output.")


### PR DESCRIPTION
Keep getting bitten by the bug in bit-docs/bit-docs#8 any time
something goes wrong with site in the generate-html plugin.

Instead of using `-f`, which also reinstalls everything from npm,
it would be nice if there were an option to just bust the cache
files that for instance generate-html produces. Essentially, `-c`.

I'm not so sure that fixing bit-docs/bit-docs#8 means this idea
becomes obsolete, because, regardless, it's nice have a guarantee
that all cache files will be regenerated when running bit-docs,
especially when debugging and wanting to eliminate cache files
without reinstalling all plugins from npm at the same time.

EDIT:

Turns out this is useful even if nothing breaks. For instance, would
be nice to have this when modifying the `bit-docs-generate-html`
default styles, which do not currently get updated without `-f`.