### PR TITLE
Make deps with file: syntax have absolute paths

### DIFF
--- a/lib/configure/configure.js
+++ b/lib/configure/configure.js
@@ -20,7 +20,7 @@ module.exports = function(pathToPackageJSON, siteConfig){
 	for (var depName in siteConfig.dependencies) {
 		var possibleFilePath = siteConfig.dependencies[depName];
 
-		if (_.startsWith(possibleFilePath, 'file:')) {
+		if (possibleFilePath.startsWith('file:')) {
 			var filePath = possibleFilePath.substr(5);
 			if( ! path.isAbsolute(filePath) ) {
 				filePath = path.join( path.dirname(pathToPackageJSON), filePath );

--- a/lib/configure/configure.js
+++ b/lib/configure/configure.js
@@ -17,6 +17,18 @@ module.exports = function(pathToPackageJSON, siteConfig){
 		siteConfig.dest = path.join( path.dirname(pathToPackageJSON), siteConfig.dest );
 	}
 
+	for (var depName in siteConfig.dependencies) {
+		var possibleFilePath = siteConfig.dependencies[depName];
+
+		if (_.startsWith(possibleFilePath, 'file:')) {
+			var filePath = possibleFilePath.substr(5);
+			if( ! path.isAbsolute(filePath) ) {
+				filePath = path.join( path.dirname(pathToPackageJSON), filePath );
+			}
+			siteConfig.dependencies[depName] = 'file:' + filePath;
+		}
+	}
+
 	var bitDocs = makeBitDocs(siteConfig);
 
 	var installedPackages;

--- a/lib/configure/configure.js
+++ b/lib/configure/configure.js
@@ -24,8 +24,8 @@ module.exports = function(pathToPackageJSON, siteConfig){
 			var filePath = possibleFilePath.substr(5);
 			if( ! path.isAbsolute(filePath) ) {
 				filePath = path.join( path.dirname(pathToPackageJSON), filePath );
+				siteConfig.dependencies[depName] = 'file:' + filePath;
 			}
-			siteConfig.dependencies[depName] = 'file:' + filePath;
 		}
 	}
 

--- a/test.js
+++ b/test.js
@@ -9,6 +9,7 @@ require("./lib/configured/npm/npm_test");*/
 var assert = require("assert");
 var docjs = require("./main.js");
 var path = require("path");
+var fs = require("fs");
 
 
 describe("bit-docs/main",function(){
@@ -24,7 +25,25 @@ describe("bit-docs/main",function(){
             }).then(function(){
             done();
         }).catch(done);
-    })
+    });
 
+    it("makes file: paths absolute", function(done){
+		var testProj = path.join(__dirname, "test", "file-pathed-deps", "test-project");
+        this.timeout(60000);
+        docjs(path.join(testProj, "package.json"), {
+			forceBuild: true,
+			debug: true
+		}).then(function(){
+			var check = path.join(testProj, "doc", "static", "bundles", "bit-docs-site", "static.css");
+			fs.readFile(check, function (err, data) {
+				if (err) throw err;
+				if (data.indexOf('local-pretty') >= 0) {
+					done();
+				} else {
+					throw new Error('expected to find local-pretty in css');
+				}
+			});
+        }).catch(done);
+    });
 
 });

--- a/test/file-pathed-deps/local-bit-docs-prettify/bit-docs.js
+++ b/test/file-pathed-deps/local-bit-docs-prettify/bit-docs.js
@@ -1,0 +1,9 @@
+module.exports = function(bitDocs){
+    var pkg = require("./package.json");
+    var dependencies = {};
+    dependencies[pkg.name] = 'file:' + __dirname;
+
+    bitDocs.register("html", {
+        dependencies: dependencies
+    });
+}

--- a/test/file-pathed-deps/local-bit-docs-prettify/package.json
+++ b/test/file-pathed-deps/local-bit-docs-prettify/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "local-bit-docs-prettify",
+  "version": "0.0.1",
+  "description": "local pretty",
+  "main": "prettify.js"
+}

--- a/test/file-pathed-deps/local-bit-docs-prettify/prettify.js
+++ b/test/file-pathed-deps/local-bit-docs-prettify/prettify.js
@@ -1,0 +1,5 @@
+require("./prettify.less")
+
+module.exports = function(){
+	console.log('local-pretty');
+}

--- a/test/file-pathed-deps/local-bit-docs-prettify/prettify.less
+++ b/test/file-pathed-deps/local-bit-docs-prettify/prettify.less
@@ -1,0 +1,6 @@
+body {
+	background:	pink;
+}
+body::after {
+	content: "local-pretty";
+}

--- a/test/file-pathed-deps/test-project/hello-world.js
+++ b/test/file-pathed-deps/test-project/hello-world.js
@@ -1,0 +1,9 @@
+/**
+ * @module {function} hello-world
+ * @description a description
+ * @body
+ * Some content
+ */
+module.exports = function(){
+	return "Hello World"
+}

--- a/test/file-pathed-deps/test-project/package.json
+++ b/test/file-pathed-deps/test-project/package.json
@@ -1,0 +1,16 @@
+{
+  "bit-docs": {
+    "dependencies": {
+      "bit-docs-glob-finder": "^0.0.5",
+      "bit-docs-dev": "^0.0.3",
+      "bit-docs-js": "^0.0.3",
+      "bit-docs-generate-html": "^0.0.3",
+	  "local-bit-docs-prettify": "file:../local-bit-docs-prettify"
+    },
+    "glob": {
+      "pattern": "**/*.{js,md}"
+    },
+    "minifyBuild": false,
+    "parent": "hello-world"
+  }
+}


### PR DESCRIPTION
Related to https://github.com/bit-docs/bit-docs-generate-html/pull/20

When you do `npm install --save` it uses syntax like `file://`, so might need to modify the code to support that case, but haven't tested if that's an issue or not.