### PR TITLE
Skip directory name matches

### DIFF
--- a/lib/process/process.js
+++ b/lib/process/process.js
@@ -3,7 +3,8 @@ var Q = require("q"),
 	processFile = require("../process/file"),
 	path = require("path"),
 	postProcess = require("./post_process"),
-	_ = require("lodash");
+	startsWith = require("lodash/startsWith");
+
 /**
  * @function documentjs.process.fileEventEmitter
  * @parent documentjs.process.methods
@@ -41,60 +42,57 @@ var Q = require("q"),
  * @body
  */
 module.exports = function processEventEmitter(fileEventEmitter, siteConfig) {
-
 	var docMap = {},
-		matched = 0,
-		processed = 0,
-		complete = false,
 		deferred = Q.defer(),
-		resolve = function(){
-			if(matched === processed && complete) {
-				// tags get to do there thing
-				try{
-					postProcess(docMap, siteConfig);
-				} catch (e){
-					deferred.reject(e);
-				}
+		matchedFilesPromises = [];
 
-
-				deferred.resolve(docMap);
-			}
-		};
-
-	fileEventEmitter.on("match",function(filePath, fileSource){
+	fileEventEmitter.on("match", function(filePath, fileSource){
 		if(siteConfig.testFinder) {
-			console.log("MATCHED: "+path.relative(process.cwd(),filePath))
+			console.log("MATCHED: "+path.relative(process.cwd(),filePath));
 			return;
 		}
 
-		matched++;
-
 		filePath = path.normalize(filePath);
 
-		if(fileEventEmitter.cwd && filePath.indexOf(fileEventEmitter.cwd) !== 0 ) {
-			var readSrc = path.join(fileEventEmitter.cwd, filePath);
-		} else {
-			var readSrc = filePath;
-		}
-		if(fileSource) {
-			processFile(filePath, fileSource.toString(), docMap, siteConfig);
-			processed++;
-			resolve();
-		} else {
-			fs.readFile(readSrc, function(err, data){
-				if(err) {
-					console.log(err);
-				}
-				processFile(filePath, data.toString(), docMap, siteConfig);
-				processed++;
-				resolve();
+		var processFilePromise;
+		var readSrc = fileEventEmitter.cwd && !startsWith(filePath, fileEventEmitter.cwd) ?
+			path.join(fileEventEmitter.cwd, filePath) :
+			filePath;
+
+		if (fileSource) {
+			// make sure this promise rejects if `processFile` throws
+			processFilePromise = Q().then(function() {
+				processFile(filePath, fileSource.toString(), docMap, siteConfig);
 			});
+		} else {
+			processFilePromise = Q.denodeify(fs.stat)(readSrc)
+				.then(function(stat) {
+					if (stat.isDirectory()) {
+						console.warn([
+							"Unable to process directory " + readSrc,
+							"Make sure docConfig.pattern matches individual source files",
+							"See https://documentjs.com/docs/DocumentJS.siteConfig.html#section_Use"
+						].join("\n"));
+					} else {
+						return Q.denodeify(fs.readFile)(readSrc)
+							.then(function(data) {
+								processFile(filePath, data.toString(), docMap, siteConfig);
+							});
+					}
+				});
 		}
+
+		matchedFilesPromises.push(processFilePromise);
 	});
-	fileEventEmitter.on("end", function(){
-		complete = true;
-		resolve();
+
+	fileEventEmitter.on("end", function() {
+		Promise.all(matchedFilesPromises)
+			.then(function() {
+				postProcess(docMap, siteConfig);
+				deferred.resolve(docMap);
+			})
+			.catch(deferred.reject);
 	});
 
 	return deferred.promise;
-}
+};

--- a/lib/process/process_test.js
+++ b/lib/process/process_test.js
@@ -3,50 +3,79 @@ var process = require("./process"),
 	fs = require("fs"),
 	path = require("path"),
 	EventEmitter = require("events"),
-	_ = require("lodash");
+	isEmpty = require("lodash/isEmpty"),
+	noop = require("lodash/noop");
 
-	describe("documentjs/lib/process", function(){
+describe("documentjs/lib/process", function(){
+	it("basics", function() {
+		var methodsCalled = [];
 
-		it("basics", function(done){
-			var methodsCalled = [];
+		var SITE_CONFIG = {
+			processors: [
+				function(filename, source, docMap, siteConfig, addToDocMap) {
+					methodsCalled.push("processor");
+					assert.equal(filename, "foo.js", "processor called with filename");
+					assert.equal(source, "hello world", "processor called with source");
+					assert.ok(isEmpty(docMap), "processor called with docMap as an empty object");
+					assert.equal(siteConfig, SITE_CONFIG, "processor called with siteConfig");
+					addToDocMap({name: "Foo"});
+				}
+			],
+			postProcessors: [
+				function(docMap, siteConfig) {
+					methodsCalled.push("postProcessor");
+					assert.deepEqual(docMap, {Foo: {name: "Foo"}}, "postProcessor called with docMap");
+					assert.equal(siteConfig, SITE_CONFIG, "postProcessor called with siteConfig");
+					docMap.expanded = {name: "expanded"};
+				}
+			]
+		};
 
-			var processor = function(filename, source, docMap, siteConfig, addToDocMap){
-				methodsCalled.push("processor");
-				assert.equal(filename, "foo.js", "processor called with filename");
-				assert.equal(source, "hello world", "processor called with source");
-				assert.ok(_.isEmpty(docMap), "processor called with docMap as an empty object");
-				assert.equal(siteConfig, SITE_CONFIG, "processor called with siteConfig");
-				addToDocMap({name: "Foo"});
-			};
+		var fileEventEmitter = new EventEmitter();
 
-			var postProcessor = function(docMap, siteConfig) {
-				methodsCalled.push("postProcessor");
-				assert.deepEqual(docMap, {Foo: {name: "Foo"}}, "postProcessor called with docMap");
-				assert.equal(siteConfig, SITE_CONFIG, "postProcessor called with siteConfig");
-				docMap.expanded = {name: "expanded"}
-			};
+		setTimeout(function(){
+			fileEventEmitter.emit("match", "foo.js", "hello world");
+			fileEventEmitter.emit("end");
+		}, 10);
 
-			var fileEventEmitter = new EventEmitter();
-			setTimeout(function(){
-				fileEventEmitter.emit('match', 'foo.js', "hello world");
-				fileEventEmitter.emit('end');
-			},10);
-			var SITE_CONFIG = {
-				processors: [processor],
-				postProcessors: [postProcessor]
-			};
-			process(fileEventEmitter, SITE_CONFIG).then(function(docMap){
-				assert.deepEqual(methodsCalled, ["processor","postProcessor"], "all 2 methods called")
-				assert.deepEqual(docMap,
-					{
-						Foo: {name: "Foo"},
-						expanded: {name: "expanded"}
-					}, "postProcessor called with docMap");
-					done();
-
-			}).catch(done);
-
+		return process(fileEventEmitter, SITE_CONFIG).then(function(docMap) {
+			assert.deepEqual(
+				methodsCalled,
+				["processor", "postProcessor"],
+				"all 2 methods called"
+			);
+			assert.deepEqual(
+				docMap,
+				{
+					Foo: {name: "Foo"},
+					expanded: {name: "expanded"}
+				},
+				"postProcessor called with docMap"
+			);
 		});
-
-
 	});
+
+	// some packages include extensions in the folder name, e.g
+	// https://www.npmjs.com/package/asn1.js; process should check if
+	// the match is a directory, otherwise `readFile` will throw
+	it("it skips directories", function() {
+		var siteConfig = {
+			processors: [noop],
+			postProcessors: [noop]
+		};
+
+		var emitter = new EventEmitter();
+
+		// point the emitter to the test folder, so `fs.readFile` can find
+		// the fixture folder named "foo.js"
+		emitter.cwd = path.join(__dirname, "..", "..", "test");
+
+		setTimeout(function() {
+			emitter.emit("match", "foo.js");
+			// emitter.emit("match", "foo.js/main.js", "hello world");
+			emitter.emit("end");
+		}, 10);
+
+		return process(emitter, siteConfig);
+	});
+});

--- a/test/foo.js/main.js
+++ b/test/foo.js/main.js
@@ -1,0 +1,9 @@
+/**
+ * @module {function} foo
+ * @description a description
+ * @body
+ * Some content
+ */
+module.exports = function() {
+	return "foo";
+};


### PR DESCRIPTION
When processing file matches, check the path does not point to a directory otherwise `bit-docs` will throw.


Closes #42