### PR TITLE
update deps to resolve security vulterabilities (fixes #53)

### DIFF
--- a/lib/configure/configure_test.js
+++ b/lib/configure/configure_test.js
@@ -6,6 +6,7 @@ var configured = require("./configured"),
 
 var Browser = require("zombie"),
 	connect = require("connect"),
+	serveStatic = require("serve-static"),
 	rmdir = require('rimraf');
 
 
@@ -38,7 +39,7 @@ var waitFor = function(browser, checker, callback, done){
 
 
 var open = function(url, callback, done){
-	var server = connect().use(connect.static(path.join(__dirname))).listen(8081);
+	var server = connect().use(serveStatic(path.join(__dirname))).listen(8081);
 	var browser = new Browser();
 	browser.visit("http://localhost:8081/"+url)
 		.then(function(){

--- a/lib/generate/generate.js
+++ b/lib/generate/generate.js
@@ -2,7 +2,6 @@ var Q = require('q');
 var processEventEmitter = require("../process/process");
 var promiseQueue = require("../promise_queue");
 var _ = require("lodash");
-var minimatch = require("minimatch");
 var fs = require("fs");
 var chokidar = require("chokidar");
 var path = require("path");

--- a/lib/generate/test/generate_test.js
+++ b/lib/generate/test/generate_test.js
@@ -1,7 +1,6 @@
 var generate = require("../generate"),
 	assert = require("assert");
 	rmdir = require('rimraf'),
-	connect = require("connect"),
 	path = require("path"),
 	slash = require("../../slash"),
 	EventEmitter = require("events")

--- a/lib/test_helpers.js
+++ b/lib/test_helpers.js
@@ -1,6 +1,8 @@
 var Browser = require("zombie"),
 	connect = require("connect"),
-	path = require("path");
+	path = require("path"),
+	serveStatic = require("serve-static")
+;
 
 var find = function(browser, property, callback, done){
 	var start = new Date();
@@ -31,7 +33,7 @@ var waitFor = function(browser, checker, callback, done){
 
 
 var open = function(url, callback, done){
-	var server = connect().use(connect.static(path.join(__dirname))).listen(8081);
+	var server = connect().use(serveStatic(path.join(__dirname))).listen(8081);
 	var browser = new Browser();
 	browser.visit("http://localhost:8081/"+url)
 		.then(function(){

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "release:major": "npm version major && npm publish"
   },
   "devDependencies": {
-    "connect": "^2.14.4",
+    "connect": "^3.6.6",
     "jshint": "^2.9.5",
     "mocha": ">= 1.18.0",
     "qunit-mocha-ui": "*",
@@ -38,10 +38,10 @@
     "enpeem": "^2.1.0",
     "fs-extra": "^0.24.0",
     "glob": "~6.0.3",
-    "q": "~1.0.1",
-    "lodash": "~4.13.1",
+    "lodash": "^4.17.5",
     "md5": "^2.0.0",
-    "minimatch": "~1.0.0",
+    "q": "~1.0.1",
+    "serve-static": "^1.13.2",
     "yargs": "^1.3.1"
   },
   "system": {


### PR DESCRIPTION
This resolves all security vulnerabilities by updating packages (and remove `minimatch` as it was unused). The test suite appears to be incomplete though, so I am unsure the best way to test these changes.